### PR TITLE
refactor(args): update to use struct

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"reflect"
+)
+
+func BindFlags(cfg any) {
+	v := reflect.ValueOf(cfg).Elem()
+	t := v.Type()
+
+	for i := range v.NumField() {
+		field := v.Field(i)
+		fieldType := t.Field(i)
+
+		flagName := fieldType.Tag.Get("flag")
+		help := fieldType.Tag.Get("help")
+		defaultValue := fieldType.Tag.Get("default")
+
+		if flagName == "" {
+			continue
+		}
+
+		switch field.Kind() {
+		case reflect.String:
+			flag.StringVar(field.Addr().Interface().(*string), flagName, defaultValue, help)
+		case reflect.Int:
+			defaultInt := 0
+			if defaultValue != "" {
+				fmt.Sscanf(defaultValue, "%d", &defaultInt)
+			}
+			flag.IntVar(field.Addr().Interface().(*int), flagName, defaultInt, help)
+		case reflect.Bool:
+			defaultBool := false
+			if defaultValue == "true" {
+				defaultBool = true
+			}
+			flag.BoolVar(field.Addr().Interface().(*bool), flagName, defaultBool, help)
+		default:
+			fmt.Printf("Unsupported field type: %s\n", field.Kind())
+		}
+	}
+}

--- a/m3u8-cli.go
+++ b/m3u8-cli.go
@@ -10,42 +10,52 @@ import (
 
 const version = "v0.0.1"
 
+type Config struct {
+	URL         string `flag:"url" default:"" help:"The URL of the .m3u8 playlist"`
+	Output      string `flag:"output" default:"output.mp4" help:"Output filename"`
+	OutputDir   string `flag:"output-dir" default:"." help:"Directory to save the output file"`
+	Timeout     int    `flag:"timeout" default:"30" help:"Timeout in seconds for stalled downloads"`
+	Quiet       bool   `flag:"quiet" default:"false" help:"Suppress ffmpeg output logs"`
+	ShowVersion bool   `flag:"version" default:"false" help:"Print the version and exit"`
+}
+
 func main() {
 	fmt.Printf("🎬 m3u8-download %s\n\n", version)
 
-	url := flag.String("url", "", "The URL of the .m3u8 playlist")
-	output := flag.String("output", "output.mp4", "Output filename")
-	outputDir := flag.String("output-dir", ".", "Directory to save the output file")
-	timeout := flag.Int("timeout", 30, "Timeout in seconds for stalled downloads")
-	quiet := flag.Bool("quiet", false, "Suppress ffmpeg output logs")
-
+	config := &Config{}
+	BindFlags(config)
 	flag.Parse()
 
-	if *url == "" {
+	if config.ShowVersion {
+		fmt.Printf("m3u8-download version: %s\n", version)
+		os.Exit(0)
+	}
+
+	if config.URL == "" {
 		fmt.Println("Error: --url flag is required")
 		os.Exit(1)
 	}
 
-	if stat, err := os.Stat(*outputDir); err != nil {
-		fmt.Printf("Error: output directory does not exist: %s\n", *outputDir)
+	if stat, err := os.Stat(config.OutputDir); err != nil {
+		fmt.Printf("Error: output directory does not exist: %s\n", config.OutputDir)
 		os.Exit(1)
 	} else if !stat.IsDir() {
-		fmt.Printf("Error: output path is not a directory: %s\n", *outputDir)
+		fmt.Printf("Error: output path is not a directory: %s\n", config.OutputDir)
 		os.Exit(1)
 	}
 
-	outputPath := filepath.Join(*outputDir, *output)
+	outputPath := filepath.Join(config.OutputDir, config.Output)
 
 	cmd := exec.Command(
 		"ffmpeg",
-		"-rw_timeout", fmt.Sprintf("%d", *timeout*1000000),
-		"-i", *url,
+		"-rw_timeout", fmt.Sprintf("%d", config.Timeout*1000000),
+		"-i", config.URL,
 		"-c", "copy",
 		"-bsf:a", "aac_adtstoasc",
 		outputPath,
 	)
 
-	if *quiet {
+	if config.Quiet {
 		cmd.Stdout = nil
 		cmd.Stderr = nil
 	} else {


### PR DESCRIPTION
This PR refactors how cli arguments are taken in. It uses the golang `reflect` and `flag` packages to read the tag metadata. This only supports `string`, `int` and, `bool`. This does not support anything else because I don't need that right now.

Right now, it reads the `flag`, `default`, and `help` tags. This is the first time I tried to read the tags and it was much easier than I thought.

Example:
```golang
type Config struct {
	URL         string `flag:"url" default:"" help:"The URL of the .m3u8 playlist"`
	Output      string `flag:"output" default:"output.mp4" help:"Output filename"`
	OutputDir   string `flag:"output-dir" default:"." help:"Directory to save the output file"`
	Timeout     int    `flag:"timeout" default:"30" help:"Timeout in seconds for stalled downloads"`
	Quiet       bool   `flag:"quiet" default:"false" help:"Suppress ffmpeg output logs"`
	ShowVersion bool   `flag:"version" default:"false" help:"Print the version and exit"`
}
```