### PR TITLE
feat(binaries): build for platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+binaries/
+m3u8-cli
+videos/

--- a/scripts/build-all-platform.sh
+++ b/scripts/build-all-platform.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+echo "🚀 Building binaries..."
+
+# Linux (amd64)
+echo "🔨 Building Linux amd64 binary..."
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o binaries/m3u8-cli-linux .
+
+# Mac (Intel x86_64)
+echo "🔨 Building Mac Intel (amd64) binary..."
+CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o binaries/m3u8-cli-mac-intel .
+
+# Mac (Apple Silicon ARM64)
+echo "🔨 Building Mac ARM64 (M1/M2/M3) binary..."
+CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o binaries/m3u8-cli-mac-arm64 .
+
+echo "✅ All binaries built successfully!"


### PR DESCRIPTION
This PR adds a script to build for `linux/amd64`, `darwin/amd64`, `darwin/arm64`.